### PR TITLE
Add metadata function pulls orderly rds from remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.sharepoint
 Title: Sharepoint Driver for Orderly
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -130,11 +130,24 @@ orderly_remote_sharepoint_ <- R6::R6Class(
       unzip_archive(zip, name, id)
     },
 
+    metadata = function(name, id) {
+      archive_path <- self$pull(name, id)
+      file.path(archive_path, "orderly_run.rds")
+    },
+
     run = function(...) {
       stop("'orderly_remote_sharepoint' remotes do not run")
     },
 
     url_report = function(name, id) {
       stop("'orderly_remote_sharepoint' remotes do not support urls")
+    },
+
+    bundle_pack = function(...) {
+      stop("'orderly_remote_sharepoint' remotes do not support bundles")
+    },
+
+    bundle_import = function(...) {
+      stop("'orderly_remote_sharepoint' remotes do not support bundles")
     }
   ))

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -39,6 +39,28 @@ test_that("pull", {
   expect_equal(dirname(args[[2]]), tempdir())
 })
 
+test_that("metadata", {
+  path <- orderly::orderly_example("minimal")
+  id <- orderly::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly::orderly_commit(id, root = path)
+  zip <- zip_dir(p)
+
+  folder <- list(download = mockery::mock(zip))
+  cl <- orderly_remote_sharepoint_$new(folder)
+  res <- cl$metadata("example", id)
+
+  expect_true(file.exists(res))
+  ## metadata can be read
+  rds <- readRDS(res)
+  expect_true(!is.null(rds))
+
+  mockery::expect_called(folder$download, 1)
+  args <- mockery::mock_args(folder$download)[[1]]
+  expect_equal(args[[1]], file.path("archive/example", id))
+  expect_match(args[[2]], "\\.zip$")
+  expect_equal(dirname(args[[2]]), tempdir())
+})
+
 
 test_that("push", {
   path <- orderly::orderly_example("minimal")
@@ -81,6 +103,14 @@ test_that("url_report is not supported", {
   cl <- orderly_remote_sharepoint_$new(NULL)
   expect_error(cl$url_report("a", "b"),
                "'orderly_remote_sharepoint' remotes do not support urls")
+})
+
+test_that("bundles are not supported", {
+  cl <- orderly_remote_sharepoint_$new(NULL)
+  expect_error(cl$bundle_pack(),
+               "'orderly_remote_sharepoint' remotes do not support bundles")
+  expect_error(cl$bundle_import(),
+               "'orderly_remote_sharepoint' remotes do not support bundles")
 })
 
 


### PR DESCRIPTION
This is so that Jeff can use `orderly_pull_archive` to get a specific report.

Have tested this from `naomi-orderly`

```
system("git clone --single-branch --branch new-country-area-scripts git@github.com:mrc-ide/naomi-orderly.git naomi-orderly-test")
setwd("naomi-orderly-test")
orderly::orderly_pull_archive("aaa_data_population_gpw", id = 'latest(parameter:iso3 == "AGO")')
```

This previously didn't work but now working with updated `orderly.sharepoint`

As an aside when Jeff originally reported he was trying to use
```
## This pulls down the task with parameter iso3 = LBR (the most recent task), not iso3 = AGO
orderly::orderly_pull_archive("aaa_data_population_gpw", parameters = list(iso3 = "AGO"))
```

but this has default `id = "latest"` but the code skips any checking of parameters if `id = "latest"`. Not clear what we want the behaviour to be here but I can make a change in orderly.