### PR TITLE
add reside-ic/spud remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.sharepoint
 Title: Sharepoint Driver for Orderly
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -20,4 +20,6 @@ Imports:
 Suggests:
     mockery,
     testthat
+Remotes:
+    reside-ic/spud    
 RoxygenNote: 7.0.2


### PR DESCRIPTION
This PR adds `reside-ic/spud` as a remote to enable a clean install of the package.  It avoids the error:

```   r
ERROR: dependency ‘spud’ is not available for package ‘orderly.sharepoint’
```