### PR TITLE
mrc-3168: Add kill function to sharepoint remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.sharepoint
 Title: Sharepoint Driver for Orderly
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -139,6 +139,10 @@ orderly_remote_sharepoint_ <- R6::R6Class(
       stop("'orderly_remote_sharepoint' remotes do not run")
     },
 
+    kill = function(...) {
+      stop("'orderly_remote_sharepoint' remotes do not support kill")
+    },
+
     url_report = function(name, id) {
       stop("'orderly_remote_sharepoint' remotes do not support urls")
     },

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -99,6 +99,13 @@ test_that("report_run is not supported", {
 })
 
 
+test_that("report_run is not supported", {
+  cl <- orderly_remote_sharepoint_$new(NULL)
+  expect_error(cl$kill("my_key"),
+               "'orderly_remote_sharepoint' remotes do not support kill")
+})
+
+
 test_that("url_report is not supported", {
   cl <- orderly_remote_sharepoint_$new(NULL)
   expect_error(cl$url_report("a", "b"),


### PR DESCRIPTION
This PR will
* Add `kill` function to sharepoint remote which will just explicitly error if users try to call it