### PR TITLE
Use orderly1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,12 +14,13 @@ Encoding: UTF-8
 LazyData: true
 Language: en-GB
 Imports:
-    orderly (>= 1.1.32),
+    orderly1 (>= 1.7.0),
     spud (>= 0.1.5),
     zip
 Suggests:
     mockery,
     testthat
 Remotes:
-    reside-ic/spud    
+    reside-ic/spud
+    orderly1=vimc/orderly@vimc-7135
 RoxygenNote: 7.0.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,6 @@ Suggests:
     mockery,
     testthat
 Remotes:
-    reside-ic/spud
+    reside-ic/spud,
     orderly1=vimc/orderly@vimc-7135
 RoxygenNote: 7.0.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![R-CMD-check](https://github.com/vimc/orderly.sharepoint/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/vimc/orderly.sharepoint/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-An [`orderly`](https://github.com/vimc/orderly) remote hosted on Sharepoint, using [`spud`](https://github.com/reside-ic/spud).  This is experimental!
+An [`orderly1`](https://github.com/vimc/orderly1) remote hosted on Sharepoint, using [`spud`](https://github.com/reside-ic/spud).  This is experimental!
 
 ### Usage
 
@@ -38,7 +38,7 @@ The configuration above lists two remotes, one "real" and one "testing", which w
 
 `orderly.sharepoint` will store files as `archive/<name>/<id>` where `<name>` is the report name and `<id>` is a zip archive of the report contents.  These must be treated as read-only and must not be modified (they do not have a file extension to help this).
 
-With this set up, then `orderly::pull_dependencies`, `orderly::pull_archive` and `orderly::push_archive` will work, and you can use your Sharepoint site to distribute orderly results within your group.
+With this set up, then `orderly1::pull_dependencies`, `orderly1::pull_archive` and `orderly1::push_archive` will work, and you can use your Sharepoint site to distribute orderly results within your group.
 
 ## License
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -19,9 +19,9 @@ test_that("list_versions calls folder$files('archive/<name>')", {
 
 
 test_that("pull", {
-  path <- orderly::orderly_example("minimal")
-  id <- orderly::orderly_run("example", root = path, echo = FALSE)
-  p <- orderly::orderly_commit(id, root = path)
+  path <- orderly1::orderly_example("minimal")
+  id <- orderly1::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly1::orderly_commit(id, root = path)
   zip <- zip_dir(p)
 
   folder <- list(download = mockery::mock(zip))
@@ -41,9 +41,9 @@ test_that("pull", {
 })
 
 test_that("metadata", {
-  path <- orderly::orderly_example("minimal")
-  id <- orderly::orderly_run("example", root = path, echo = FALSE)
-  p <- orderly::orderly_commit(id, root = path)
+  path <- orderly1::orderly_example("minimal")
+  id <- orderly1::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly1::orderly_commit(id, root = path)
   zip <- zip_dir(p)
 
   folder <- list(download = mockery::mock(zip))
@@ -65,9 +65,9 @@ test_that("metadata", {
 
 
 test_that("push", {
-  path <- orderly::orderly_example("minimal")
-  id <- orderly::orderly_run("example", root = path, echo = FALSE)
-  p <- orderly::orderly_commit(id, root = path)
+  path <- orderly1::orderly_example("minimal")
+  id <- orderly1::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly1::orderly_commit(id, root = path)
 
   folder <- list(create = mockery::mock(), upload = mockery::mock())
 

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -2,9 +2,9 @@ context("tools")
 
 test_that("unpack archive", {
   testthat::skip_on_cran()
-  path <- orderly::orderly_example("minimal")
-  id <- orderly::orderly_run("example", root = path, echo = FALSE)
-  p <- orderly::orderly_commit(id, root = path)
+  path <- orderly1::orderly_example("minimal")
+  id <- orderly1::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly1::orderly_commit(id, root = path)
 
   zip <- zip_dir(p)
 
@@ -43,7 +43,7 @@ test_that("unpack failure: not an orderly archive", {
 
 test_that("unpack failure: not expected id", {
   testthat::skip_on_cran()
-  id <- orderly:::new_report_id()
+  id <- orderly1:::new_report_id()
   tmp <- file.path(tempfile(), id)
   dir.create(tmp, FALSE, TRUE)
   dir.create(file.path(tmp, "orderly.yml"))
@@ -56,7 +56,7 @@ test_that("unpack failure: not expected id", {
 
 test_that("unpack failure: missing files", {
   testthat::skip_on_cran()
-  id <- orderly:::new_report_id()
+  id <- orderly1:::new_report_id()
   tmp <- file.path(tempfile(), id)
   dir.create(tmp, FALSE, TRUE)
   dir.create(file.path(tmp, "orderly.yml"))


### PR DESCRIPTION
This Pr updates references to orderly to orderly1 - this turns out only to be in the tests really